### PR TITLE
Add hover button for CTAs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,8 @@
 These are the initiatives that drive our work now and in the future.
 See [About the roadmap](./about.md) for what these mean, how they fit into our workflow, and how you can engage with us.
 
+Interested in funding one of these initiatives? [Fill out our funding interest form](https://docs.google.com/forms/d/e/1FAIpQLScItiSZ9l2cqtpw5T3bVejFIQ3-cz15EESt_P3PczUWMScXTA/viewform).
+
 +++ {"class": "col-page-inset"}
 
 ## 🚀 In-Flight Initiatives

--- a/docs/plugins/issue-board/render.mjs
+++ b/docs/plugins/issue-board/render.mjs
@@ -102,6 +102,17 @@ export function renderItem(item, ctx) {
       },
     ],
   });
+  // CTA button for non-completed items (visible on hover, only icon is always visible on touchscreen)
+  if (item.status !== "Done") {
+    rightChildren.push({
+      type: "link", url: `https://docs.google.com/forms/d/e/1FAIpQLScItiSZ9l2cqtpw5T3bVejFIQ3-cz15EESt_P3PczUWMScXTA/viewform?usp=pp_url&entry.384914845=${encodeURIComponent(item.url)}`, class: "issue-board-cta",
+      children: [
+        { type: "span", class: "issue-board-cta-text", children: [{ type: "text", value: "Fund this " }] },
+        { type: "span", class: "issue-board-cta-icon", children: [{ type: "text", value: "💰" }] },
+      ],
+    });
+  }
+
   if (item.status === "Done") {
     const label = formatTimeAgo(item.closedAt, "Completed");
     if (label) {

--- a/docs/style/custom.css
+++ b/docs/style/custom.css
@@ -91,6 +91,45 @@
   color: #999;
 }
 
+/* CTA button: hidden by default, shown on row hover */
+.issue-board-cta {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  background: none;
+  border: 1px solid #ccc;
+  color: #777 !important;
+  text-decoration: none !important;
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+/* Hide the external-link icon MyST adds */
+.issue-board-cta svg {
+  display: none !important;
+}
+
+.issue-board-details > summary:hover .issue-board-cta {
+  opacity: 1;
+}
+
+.issue-board-cta:hover {
+  border-color: #8250df;
+  color: #8250df !important;
+}
+
+/* Mobile: always show as emoji-only icon */
+@media (hover: none) {
+  .issue-board-cta {
+    opacity: 1;
+    font-size: 0.75rem;
+  }
+  .issue-board-cta-text {
+    display: none;
+  }
+}
+
 /* Expanded body: strip theme padding, indent nested content */
 .issue-board-details .myst-dropdown-body {
   padding: 0.2rem 0 0.5rem 2.5rem !important;


### PR DESCRIPTION
This adds a little hover button for a funding CTA. Here are the main changes:

- A link to the google form at the top of the roadmap
- A hoverable button that includes a link to each initiative.
- That button is _always_ visible and only an icon on mobile.